### PR TITLE
Guard against whitespace in $BROWSERBIN variable

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -30,7 +30,7 @@ else
 	fi
 fi
 
-if [ -n "$BROWSERBIN" ] && [ ! -x $BROWSERBIN ]; then
+if [ -n "$BROWSERBIN" ] && [ ! -x "$BROWSERBIN" ]; then
 	echo "Installing browser."
 	./node_modules/travis-multirunner/setup.sh
 fi
@@ -43,7 +43,7 @@ if [ -n "$BROWSERSTACK" ]; then
 	$SCRIPTDIR/browserstacklocal-start
 fi
 
-export BROWSERBIN=$BROWSERBIN
+export BROWSERBIN="$BROWSERBIN"
 # Karma uses ${BROWSER}_BIN, eg. CHROME_BIN, to override the path to the browser
 BROWSER_UPPER=$(echo "$BROWSER" | tr '[:lower:]' '[:upper:]')
 export ${BROWSER_UPPER}_BIN="$BROWSERBIN"


### PR DESCRIPTION
I've gotten a "[:too many arguments" error a few times because $BROWSERBIN has spaces. This just surrounds it with quotes.