### PR TITLE
Allow running Firefox tests on Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ matrix:
     - os: linux
       sudo: false
       env: BROWSER=edge BVER='17.17134' SAUCELABS=true
+    - os: osx
+      addons:
+        firefox: "latest"
+      env: BROWSER=firefox BVER=stable
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - os: osx
       addons:
         firefox: "latest"
-      env: BROWSER=firefox BVER=stable
+      env: BROWSER=firefox BVER=stable INTEGRATION_CMD=''
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 before_install:
 - export DISPLAY=:99.0
 - if [ -f /etc/init.d/xvfb ]; then sh -e /etc/init.d/xvfb start; fi
-- if [ $BROWSER == 'firefox' ]; then pulseaudio --start; fi
+- if [ -x "$(command -v pulseaudio)" ] && [ "$BROWSER" == "firefox" ]; then pulseaudio --start; fi
 before_script:
 - npm start > /dev/null &
 - if [ "$BROWSER" = "ie" ]; then ./plugin-installer/packageSauceLabsInstaller.sh https://tbdev.tokbox.com/v2; fi

--- a/run-tests
+++ b/run-tests
@@ -14,8 +14,8 @@ if [ -z $BVER ]; then
 fi
 
 if [ ! -n "$BROWSERBIN" ]; then
-	if [ -z $TRAVIS ]; then
-		echo "No TRAVIS env variable, we must be running locally. Assuming OSX."
+	if [[ $OSTYPE == darwin* ]]; then
+		echo "We are running on Mac OS let's check if the browsers are already installed"
 		case ${BROWSER}-${BVER} in
 			chrome-stable) BROWSERBIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";;
 			chrome-beta) BROWSERBIN="/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome";;
@@ -33,6 +33,8 @@ if [ ! -n "$BROWSERBIN" ]; then
 fi
 
 if [ -n "$BROWSERBIN" ] && [ ! -x $BROWSERBIN ] && [ ! -n "$SAUCELABS" ] && [ ! -n "$BROWSERSTACK" ]; then
+	# If the browser isn't already installed then we install it using travis multirunner
+	# Travis multirunner also handles setting up Safari to allow camera access and fake devices
 	echo "Installing browser using travis multirunner."
 	./node_modules/travis-multirunner/setup.sh
 fi

--- a/run-tests
+++ b/run-tests
@@ -32,7 +32,7 @@ if [ ! -n "$BROWSERBIN" ]; then
 	fi
 fi
 
-if [ -n "$BROWSERBIN" ] && [ ! -x $BROWSERBIN ] && [ ! -n "$SAUCELABS" ] && [ ! -n "$BROWSERSTACK" ]; then
+if [ "$BROWSER" == "safari" ] || ([ -n "$BROWSERBIN" ] && [ ! -x $BROWSERBIN ] && [ ! -n "$SAUCELABS" ] && [ ! -n "$BROWSERSTACK" ]); then
 	# If the browser isn't already installed then we install it using travis multirunner
 	# Travis multirunner also handles setting up Safari to allow camera access and fake devices
 	echo "Installing browser using travis multirunner."


### PR DESCRIPTION
We're using the Firefox addon for Travis and making it if you're on Mac OS then it doesn't try to use travis-multirunner.